### PR TITLE
Fix two issues

### DIFF
--- a/pykicad/module.py
+++ b/pykicad/module.py
@@ -494,6 +494,10 @@ class Module(AST):
             '_parser': Pad,
             '_multiple': True
         },
+        'polygons': {
+            '_parser': Polygon,
+            '_multiple': True
+        },
         'model': {
             '_parser': Model,
             '_multiple': True

--- a/pykicad/module.py
+++ b/pykicad/module.py
@@ -55,7 +55,8 @@ def list_all_modules():
 
 def flip_layer(layer):
     side, layer = layer.split('.')
-    side = 'B' if side == 'F' else 'B'
+    if side != '*':
+        side = 'B' if side == 'F' else 'B'
     return side + '.' + layer
 
 


### PR DESCRIPTION
Lumping these two together because they are both trivial and the overhead of doing separate PRs seems unwarranted.

The two issues are:

* When `flip()` is applied to footprints that have eg: `*.Cu` set as a layer, we would force the component to one side, breaking its multi-layer-ness.  I've resolved this here by explicitly checking for `*`.
* `Module` allowed building footprints containing polygons, but not loading them.  This sort of footprint is generatable via https://github.com/mtl/svg2mod.  I've resolved this by adding the polygon parser.