### PR TITLE
Add support for flipping arcs. 

### DIFF
--- a/pykicad/module.py
+++ b/pykicad/module.py
@@ -74,6 +74,8 @@ def flip_layer(layer):
         side, layer = layer.split('.')
         side = 'B' if side == 'F' else 'B'
         return side + '.' + layer
+    print("Warning: Unable to determine side of layer: "+str(layer))
+    return layer
 
 
 ###########################
@@ -359,7 +361,9 @@ class Arc(AST):
     def flip(self):
         '''Flip an arc.'''
         self.layer = flip_layer(self.layer)
-        raise NotImplementedError()
+
+        self.start[1] = -self.start[1];
+        self.end[1] = -self.end[1];
 
 
 class Polygon(AST):


### PR DESCRIPTION
I was running into issues flipping footprints that were acquired through Mouser's part library, due to the footprints often having arc features (which flip was not supported for). After fixing those I ran into an issue of the flip_layer functionality choking on features that were in layers that were not tied to the front or the back of a board (ex. Dwgs.User). 

So, I additionally made the flip functionality more robust to handle layers that aren't either on the top or bottom of the board (such as user drawings). When the flip function is called and it encounters one of these layers a warning is printed, and the feature stays on the original layer instead of being moved to the None layer as was done previously. 

This allowed me to to use this library to layout footprints that were acquired from Mouser's part library. 