### PR TITLE
Added 'offset' as alias of 'at' keyword for 3D models in .kicad_mod f…

### DIFF
--- a/pykicad/module.py
+++ b/pykicad/module.py
@@ -450,6 +450,12 @@ class Model(AST):
                 '_attr': 'at'
             }
         },
+        'offset': {
+            'xyz': {
+                '_parser': tuple_parser(3),
+                '_attr': 'at'
+            }
+        },
         'scale': {
             'xyz': {
                 '_parser': tuple_parser(3),


### PR DESCRIPTION
…iles.

I ran into some [`.kicad_mod` files](https://github.com/SnowMB/pcb_library/tree/master/footprints.pretty) that use `offset` instead of `at` in their 3D model field. I don't know if this is an older keyword that's no longer used or if it's a mistake. To fix the problem, I just added `offset` as an alias for `at`.